### PR TITLE
vagrant: fix for errors on macOS

### DIFF
--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -4,12 +4,12 @@
 class Vagrant < Formula
   desc "Development environment"
   homepage "https://www.vagrantup.com/"
+  url "https://releases.hashicorp.com/vagrant/2.3.7/vagrant_2.3.7_linux_amd64.zip"
   version "2.3.7"
+  sha256 "4f5f6c55f9cb3ede37cd4a928f023e7ec0a3328125e76ae1166dc7908f1f48cb"
 
-  if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.3.7/vagrant_2.3.7_linux_amd64.zip"
-    sha256 "4f5f6c55f9cb3ede37cd4a928f023e7ec0a3328125e76ae1166dc7908f1f48cb"
-  end
+  depends_on arch: :x86_64
+  depends_on :linux
 
   conflicts_with "vagrant"
 


### PR DESCRIPTION
Gating the URL behind an if statement causes errors on any macOS Homebrew installation that uses this tap. Instead, use `depends_on` to ensure only Linux on Intel can install it.

For example:
```console
$ brew readall hashicorp/tap
Error: Invalid formula (sonoma): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
Error: Invalid formula (arm64_sonoma): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
Error: Invalid formula (ventura): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
Error: Invalid formula (arm64_ventura): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
…
```